### PR TITLE
Allow to choose opset version

### DIFF
--- a/sclblonnx/main.py
+++ b/sclblonnx/main.py
@@ -65,6 +65,7 @@ def graph_to_file(
         graph: xpb2.GraphProto,
         filename: str,
         _producer: str = "sclblonnx",
+        onnx_opset_version = 12,
         **kwargs):
     """ graph_to_file stores an onnx graph to a .onnx file
 
@@ -74,7 +75,7 @@ def graph_to_file(
         graph: An onnx graph
         filename: The filename of the resulting file
         _producer: Optional string with producer name. Default 'sclblonnx'
-
+        onnx_opset_version: Optional version number for ONNX opset. Default 12
     Returns:
         True if successful, False otherwise.
     """
@@ -88,7 +89,7 @@ def graph_to_file(
     try:
         if not 'opset_imports' in kwargs:
             op = onnx.OperatorSetIdProto()
-            op.version = 12
+            op.version = onnx_opset_version
             mod = xhelp.make_model(graph, producer_name=_producer, opset_imports=[op], **kwargs)
         else:
             mod = xhelp.make_model(graph, producer_name=_producer, **kwargs)
@@ -111,6 +112,7 @@ def run(
         inputs: {},
         outputs: [],
         _tmpfile: str = ".tmp.onnx",
+        onnx_opset_version = 12,
         **kwargs):
     """ run executes a give graph with the given input and returns the output
 
@@ -119,12 +121,13 @@ def run(
         inputs: an object with the named inputs; please check the data types
         outputs: list of named outputs
         _tmpfile: String the temporary filename for the onnx file to run.
-
+        onnx_opset_version: Optional version number for ONNX opset. Default 12
+        
     Returns:
         The result (or False if it fails somewhere)
         """
 
-    store = graph_to_file(graph, _tmpfile)
+    store = graph_to_file(graph, _tmpfile, onnx_opset_version=onnx_opset_version)
     if not store:
         _print("Unable to store model for evaluation.")
         return False


### PR DESCRIPTION
Layers like "Pad" have changed their inputs with later opset versions. Allow to choose the opset version for writing and performing inference to be able to deal with graphs based on older opsets. Please note, that kwargs would not work as save throws if unknown arguments are provided.