### PR TITLE
Update the ONNX version to go up to 1.11

### DIFF
--- a/sclblonnx/supported_onnx.json
+++ b/sclblonnx/supported_onnx.json
@@ -1,7 +1,7 @@
 {
   "onnx_version" : {
     "version_min" : "1.7.0",
-    "version_max" : "1.8.1",
+    "version_max" : "1.11.0",
     "ir_version_min" : 7,
     "ir_version_max" : 8,
     "opset_min" : 12,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'onnxruntime',
-        'onnx==1.8.1',
+        'onnx>=1.7.0,<=1.11.0',
         'requests',
         'onnxoptimizer',
         'onnx-simplifier',


### PR DESCRIPTION
I ran the tests locally, and got a single failure:
![image](https://user-images.githubusercontent.com/15835006/172226031-74df2fc6-2a6d-4e42-ae00-4205bd50f5fd.png)

It's just loading the ONNX_VERSION_INFO prematurely somehow. I'm assuming this is due to me having something incorrectly setup and not an actual failure induced by these changes.  Let me know if you think this is related to these code changes and not my setup, and I can look into the failure further.  