### PR TITLE
Update to support ONNX 1.12.0

### DIFF
--- a/sclblonnx/supported_onnx.json
+++ b/sclblonnx/supported_onnx.json
@@ -1,7 +1,7 @@
 {
   "onnx_version" : {
     "version_min" : "1.7.0",
-    "version_max" : "1.11.0",
+    "version_max" : "1.12.0",
     "ir_version_min" : 7,
     "ir_version_max" : 8,
     "opset_min" : 12,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'onnxruntime',
-        'onnx>=1.7.0,<=1.11.0',
+        'onnx>=1.7.0,<=1.12.0',
         'requests',
         'onnxoptimizer',
         'onnx-simplifier',


### PR DESCRIPTION
Similarly to this previous PR to support 1.11.0 https://github.com/scailable/sclblonnx/pull/37, this updates the lib to support ONNX version 1.12.0. I have the same test issue, but all other tests are passing.

Thanks for the great work so far! 