### PR TITLE
support onnx latest

### DIFF
--- a/sclblonnx/supported_onnx.json
+++ b/sclblonnx/supported_onnx.json
@@ -1,7 +1,7 @@
 {
   "onnx_version" : {
     "version_min" : "1.7.0",
-    "version_max" : "1.12.0",
+    "version_max" : "1.14.1",
     "ir_version_min" : 7,
     "ir_version_max" : 8,
     "opset_min" : 12,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'onnxruntime',
-        'onnx>=1.7.0,<=1.12.0',
+        'onnx>=1.7.0,<=1.14.1',
         'requests',
         'onnxoptimizer',
         'onnx-simplifier',


### PR DESCRIPTION
I've tested that all of the unit tests pass with onnx==1.14.1.
One detail regarding that is there appears to be a pathing issue in the tests. They pass if run from the test directory, but not from the base directory. I can attempt to sort that out as well if desired.