### PR TITLE
support onnx 1.13.1

### DIFF
--- a/sclblonnx/supported_onnx.json
+++ b/sclblonnx/supported_onnx.json
@@ -1,7 +1,7 @@
 {
   "onnx_version" : {
     "version_min" : "1.7.0",
-    "version_max" : "1.12.0",
+    "version_max" : "1.13.1",
     "ir_version_min" : 7,
     "ir_version_max" : 8,
     "opset_min" : 12,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=[
         'numpy',
         'onnxruntime',
-        'onnx>=1.7.0,<=1.12.0',
+        'onnx>=1.7.0,<=1.13.1',
         'requests',
         'onnxoptimizer',
         'onnx-simplifier',


### PR DESCRIPTION
All tests pass using pytest with onnx 1.13.1 with the exception of a test that fails regardless of onnx version (`test.test_utils.test__load_version_info`).